### PR TITLE
Fjerner if-sjekken som setter deilingsprosent 50 ved unddervalg MD

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdService.kt
@@ -348,8 +348,6 @@ class BarnetrygdService(
         var delingsprosent = SkatteetatenPeriode.Delingsprosent.usikker
         if (undervalg.any { it == "EF" || it == "EU" }) {
             delingsprosent = SkatteetatenPeriode.Delingsprosent._0
-        } else if (undervalg.contains("MD")) {
-            delingsprosent = SkatteetatenPeriode.Delingsprosent._50
         }
         return delingsprosent
     }

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdServiceTest.kt
@@ -378,7 +378,7 @@ internal class BarnetrygdServiceTest {
             assertThat(it.brukere.first().perioder.first().fraMaaned).isEqualTo("2019-01")
             assertThat(it.brukere.first().perioder.first().tomMaaned).isEqualTo("2019-10")
             assertThat(it.brukere.first().perioder.first().
-            delingsprosent).isEqualTo(SkatteetatenPeriode.Delingsprosent._50)
+            delingsprosent).isEqualTo(SkatteetatenPeriode.Delingsprosent.usikker)
             assertThat(it.brukere.first().sisteVedtakPaaIdent).isEqualTo(LocalDateTime.of(2020, 5, 1, 0, 0))
         }
 


### PR DESCRIPTION
.Beholder istedet verdien usikker, som er mer i tråd med hva infotrygd setter i batch-filen