### PR TITLE
Filterer vekk kun barn med støndadstype N/FJ/IN)

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdService.kt
@@ -94,7 +94,7 @@ class BarnetrygdService(
             opphørtIver = stønad.opphørtIver,
             opphørtFom = stønad.opphørtFom,
             opphørsgrunn = stønad.opphørsgrunn,
-            barn = barnRepository.findBarnByPersonkey(stønad.personKey).filter { it.stønadstype.isNullOrBlank() }
+            barn = barnRepository.findBarnByPersonkey(stønad.personKey).filter { it.stønadstype.isNullOrBlank() || it.stønadstype !in listOf("N", "FJ", "IN") }
                 .map { it.toBarnDto() },
             delytelse = vedtakRepository.hentVedtak(stønad.fnr.asString, stønad.sakNr.trim().toLong(), stønad.saksblokk)
                 .sortedBy { it.vedtakId }


### PR DESCRIPTION
Tore:
Hei Stig! Holder på med patching av tilfeller slik at du/dere skal få migrert dem. Kommer da over to-tre tilfeller i kategorien "Oppgitt antall barn ulikt antall barnidenter", hvor jeg mener at antall barn er riktig. MEN, i disse sakene ser jeg at det finnes "SK-barn", altså at de har verdien SK i feltet B10-STONADS-TYPE. Lurer derfor på om dere IKKE teller med disse i antall barn? De skal telles med som helt vanlige barn, det er bare de som ligger med 'N', 'FJ', 'IN' som IKKE skal telles. SK er "Særkullsbarn", tidligere var det en egen sats som ble utbetalt ved slike barn. Men det er det ikke lenger.

Test i preprod:
Før
![Screenshot 2022-10-06 at 16 24 45](https://user-images.githubusercontent.com/1121978/194339474-967860c4-2877-4f84-b772-14771a661d6c.png)
Etter
![Screenshot 2022-10-06 at 16 25 50](https://user-images.githubusercontent.com/1121978/194339497-e437e35b-49ed-4e74-aa3e-cd9e8205b527.png)
