### PR TITLE
Tea-9958_fjern_ba_mottak

### DIFF
--- a/nais/dev-fss.yml
+++ b/nais/dev-fss.yml
@@ -62,9 +62,6 @@ spec:
         - application: familie-ba-sak
           namespace: teamfamilie
           cluster: dev-gcp
-        - application: familie-ba-mottak
-          namespace: teamfamilie
-          cluster: dev-fss
         - application: familie-baks-mottak
           namespace: teamfamilie
           cluster: dev-gcp

--- a/nais/prod-fss.yml
+++ b/nais/prod-fss.yml
@@ -63,9 +63,6 @@ spec:
         - application: familie-ba-sak
           namespace: teamfamilie
           cluster: prod-gcp
-        - application: familie-ba-mottak
-          namespace: teamfamilie
-          cluster: prod-fss
         - application: familie-baks-mottak
           namespace: teamfamilie
           cluster: prod-gcp


### PR DESCRIPTION
Vi fjerner familie-ba-mottak(fss) da familie-baks-mottak(gcp) har tatt over.