### PR TITLE
Fix: Datofilter for perioder til pensjon med stønadTom lik fraDato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdService.kt
@@ -167,7 +167,7 @@ class BarnetrygdService(
             .filter { filtrerStønaderSomErFeilregistrert(it) }
 
         val perioder = konverterTilDtoForPensjon(barnetrygdStønader, fraDato.year).filter {
-            skalFiltreresPåDato(fraDato, it.stønadFom, it.stønadTom)
+            it.stønadTom.isSameOrAfter(fraDato)
         }
 
         if (perioder.isEmpty()) {

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/testutil/TestData.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/testutil/TestData.kt
@@ -165,6 +165,7 @@ object TestData {
         stønad: Stønad,
         kontonummer: String = "06010000",
         beløp: Double = 1054.00,
+        utbetalingTom: String? = null,
     ): Utbetaling {
         return Utbetaling(
             personKey = stønad.personKey,
@@ -175,7 +176,7 @@ object TestData {
             beløp = beløp,
             fnr = stønad.fnr,
             utbetalingId = nextId(),
-            utbetalingTom = stønad.opphørtFom
+            utbetalingTom = utbetalingTom ?: stønad.opphørtFom
         )
     }
 


### PR DESCRIPTION
Endrer datofilter til samme oppførsel som i [PensjonService](https://github.com/navikt/familie-ba-sak/blob/main/src/main/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonService.kt#L111) i Ba-sak, slik at disse periodene også inkluderes her