### PR TITLE
Endrer Stønad.fnr til nullable

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/model/dl1/Stønad.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/model/dl1/Stønad.kt
@@ -34,7 +34,7 @@ data class Stønad(
 
     @Column(name = "F_NR", columnDefinition = "VARCHAR2")
     @Convert(converter = ReversedFoedselNrConverter::class)
-    val fnr: FoedselsNr,
+    val fnr: FoedselsNr?,
 
     @Column(name = "TK_NR", columnDefinition = "VARCHAR2")
     val tkNr: String,

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdService.kt
@@ -104,9 +104,11 @@ class BarnetrygdService(
             opphørtFom = stønad.opphørtFom,
             opphørsgrunn = stønad.opphørsgrunn,
             barn = hentBarnMedGyldigStønadstypeTilknyttetPerson(stønad.personKey).map { it.toBarnDto() },
-            delytelse = vedtakRepository.hentVedtak(stønad.fnr.asString, stønad.sakNr.trim().toLong(), stønad.saksblokk)
-                .sortedBy { it.vedtakId }
-                .lastOrNull()?.delytelse?.sortedBy { it.id.linjeId }?.map { it.toDelytelseDto() } ?: emptyList(),
+            delytelse = stønad.fnr?.let {
+                vedtakRepository.hentVedtak(it.asString, stønad.sakNr.trim().toLong(), stønad.saksblokk)
+                    .sortedBy { it.vedtakId }
+                    .lastOrNull()?.delytelse?.sortedBy { it.id.linjeId }?.map { it.toDelytelseDto() }
+            } ?: emptyList(),
             antallBarn = stønad.antallBarn,
             mottakerNummer = hentMottakerNummer(stønad)
         )
@@ -324,7 +326,7 @@ class BarnetrygdService(
             stonadRepository.findKlarForMigrering(PageRequest.of(page, size), valg, undervalg)
         }
 
-        return Pair(stønader.map { it.fnr.asString }.toSet(), stønader.totalPages)
+        return Pair(stønader.mapNotNull { it.fnr?.asString }.toSet(), stønader.totalPages)
     }
 
     fun finnSisteVedtakPåPerson(personKey: Long): YearMonth {

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/testutil/TestData.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/testutil/TestData.kt
@@ -61,7 +61,7 @@ object TestData {
     ): Barn {
         return Barn(
             id = nextId(),
-            fnr = stønad.fnr,
+            fnr = stønad.fnr!!,
             tkNr = stønad.tkNr,
             personKey = stønad.personKey,
             barnFnr = barnFnr,
@@ -174,7 +174,7 @@ object TestData {
             kontonummer = kontonummer,
             utbetalingstype = "M",
             beløp = beløp,
-            fnr = stønad.fnr,
+            fnr = stønad.fnr!!,
             utbetalingId = nextId(),
             utbetalingTom = utbetalingTom ?: stønad.opphørtFom
         )
@@ -198,7 +198,7 @@ object TestData {
             resultat = "I",
             vedtaksdato = LocalDate.now(),
             iverksattdato = LocalDate.now(),
-            fnr = stønad.fnr,
+            fnr = stønad.fnr!!,
             tkNr = stønad.tkNr
         )
     }


### PR DESCRIPTION
Det hender en sjelden gang iblant at ReversedFoedselNrConverter returnerer null fordi dataen mangler i db, og vi har en
JournalhendelseRutingTask i baks-mottak som har feilet pga. vi ikke håndterer potensielle nullverdier der,