### PR TITLE
Barnetrygd til pensjon: Håntering av overlappende perioder med samme fomDato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/rest/controller/PensjonController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/rest/controller/PensjonController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.infotrygd.rest.controller
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.micrometer.core.annotation.Timed
 import io.swagger.v3.oas.annotations.Operation
@@ -83,7 +84,9 @@ class PensjonController(
         val sakstypeEkstern: SakstypeEkstern,
         val kildesystem: String = "Infotrygd",
         val pensjonstrygdet: Boolean? = null,
-        val norgeErSekundærland: Boolean? = null
+        val norgeErSekundærland: Boolean? = null,
+        @JsonIgnore
+        val iverksatt: YearMonth? = null // kun til bruk som filtreringskriterie i tilfeller hvor to perioder overlapper fra dag 1
     )
 
     enum class YtelseTypeEkstern {

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdServiceTest.kt
@@ -179,7 +179,8 @@ internal class BarnetrygdServiceTest {
                 stønadTom = YearMonth.from(LocalDate.MAX),
                 kildesystem = "Infotrygd",
                 utbetaltPerMnd = 1054,
-                sakstypeEkstern = PensjonController.SakstypeEkstern.NASJONAL
+                sakstypeEkstern = PensjonController.SakstypeEkstern.NASJONAL,
+                iverksatt = YearMonth.of(2020, 5)
             )
         )
     }
@@ -202,7 +203,8 @@ internal class BarnetrygdServiceTest {
                     stønadTom = YearMonth.from(LocalDate.MAX),
                     kildesystem = "Infotrygd",
                     utbetaltPerMnd = 1054,
-                    sakstypeEkstern = PensjonController.SakstypeEkstern.NASJONAL
+                    sakstypeEkstern = PensjonController.SakstypeEkstern.NASJONAL,
+                    iverksatt = YearMonth.of(2020, 5)
                 )
             }
         )
@@ -234,7 +236,8 @@ internal class BarnetrygdServiceTest {
                 stønadTom = relatertSakOpphørtFom,
                 kildesystem = "Infotrygd",
                 utbetaltPerMnd = SATS_UTVIDET.toInt(),
-                sakstypeEkstern = PensjonController.SakstypeEkstern.NASJONAL
+                sakstypeEkstern = PensjonController.SakstypeEkstern.NASJONAL,
+                iverksatt = YearMonth.of(2019, 5)
             )
         )
     }
@@ -259,7 +262,8 @@ internal class BarnetrygdServiceTest {
                 stønadTom = YearMonth.from(LocalDate.MAX),
                 kildesystem = "Infotrygd",
                 utbetaltPerMnd = 1054,
-                sakstypeEkstern = PensjonController.SakstypeEkstern.NASJONAL
+                sakstypeEkstern = PensjonController.SakstypeEkstern.NASJONAL,
+                iverksatt = YearMonth.of(2019, 5)
             )
         )
     }
@@ -281,6 +285,23 @@ internal class BarnetrygdServiceTest {
 
                 assertThat(periode1.stønadTom).isEqualTo(periode2.stønadFom.minusMonths(1))
             }
+    }
+
+    @Test
+    fun `finn barnetrygd for pensjon - håndterer fullstendige overlapp (lik fomDato) ved å velge perioden senest iverksatt`() {
+        val person = settOppLøpendeUtvidetBarnetrygd() //  stønad fom 2020-05, iverksatt 2020-05
+        leggTilUtgåttUtvidetBarnetrygdSak(
+            virkningFom = (999999 - 202005).toString(), // stønad fom 2020-05, iverksatt 2019-05
+            person = person,
+            opphørtFom = YearMonth.of(2022, 1).format(DateTimeFormatter.ofPattern("MMyyyy")),
+            barnFnr = barnRepository.findBarnByPersonkey(person.personKey).single().barnFnr
+        )
+
+        val barnetrygdPerioder =
+            barnetrygdService.finnBarnetrygdForPensjon(person.fnr, YearMonth.of(2020, 1)).single().barnetrygdPerioder
+
+        assertThat(barnetrygdPerioder).hasSize(1)
+        assertThat(barnetrygdPerioder.single().iverksatt).isEqualTo(barnetrygdService.finnSisteVedtakPåPerson(person.personKey))
     }
 
     @Test
@@ -311,7 +332,8 @@ internal class BarnetrygdServiceTest {
                 stønadTom = fraDato,
                 kildesystem = "Infotrygd",
                 utbetaltPerMnd = 1054,
-                sakstypeEkstern = PensjonController.SakstypeEkstern.NASJONAL
+                sakstypeEkstern = PensjonController.SakstypeEkstern.NASJONAL,
+                iverksatt = YearMonth.of(2020, 5)
             )
         )
     }


### PR DESCRIPTION
Fikser håntering av overlappende perioder med samme fomDato, sånn at man unngår meningsløse perioder med tomDato  før fomDato, ved å velge perioden tilhørende stønaden med senest iverksatt-dato