### PR TITLE
Pensjon: Fikser fastsettelsen av stønadTom for enkelte caser

### DIFF
--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdServiceTest.kt
@@ -233,7 +233,7 @@ internal class BarnetrygdServiceTest {
                 delingsprosentYtelse = YtelseProsent.USIKKER,
                 ytelseTypeEkstern = YtelseTypeEkstern.UTVIDET_BARNETRYGD,
                 stønadFom = YearMonth.of(2019, 5),
-                stønadTom = relatertSakOpphørtFom,
+                stønadTom = relatertSakOpphørtFom.minusMonths(1),
                 kildesystem = "Infotrygd",
                 utbetaltPerMnd = SATS_UTVIDET.toInt(),
                 sakstypeEkstern = PensjonController.SakstypeEkstern.NASJONAL,


### PR DESCRIPTION
Endrer `stønadTom` til `minOf(utbetalingTom, barnetsOpphørsdato)`etter å ha fått bekreftet fra loggene at det i enkelte tilfeller kan bli feil å bare se på `utbetalingTom`. Fjerner samtidig noen linjer med kode som ikke er i bruk lenger, samt logg-utskriftene brukt til debugging