### PR TITLE
Fikser hibernate feil oppstått ved henting av stønad

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/model/db2/DelytelseId.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/model/db2/DelytelseId.kt
@@ -9,5 +9,5 @@ data class DelytelseId(
     @Column(name = "VEDTAK_ID", columnDefinition = "DECIMAL")
     val vedtakId: Long,
     @Column(name = "LINJE_ID", columnDefinition = "DECIMAL")
-    val linjeId: Long
+    val linjeId: Long?
 ) : Serializable


### PR DESCRIPTION
Forsøker å la DelytelseId.linjeId være nullable for å fikse følgende hibernate feil: [PropertyAccessException, IllegalArgumentException] Can not set final long field no.nav.familie.ba.infotrygd.model.db2.DelytelseId.linjeId to null value.

Testet Ok i preprod