### PR TITLE
Update prod-fss.yml

### DIFF
--- a/nais/prod-fss.yml
+++ b/nais/prod-fss.yml
@@ -26,8 +26,8 @@ spec:
     initialDelay: 120
     timeout: 1
   replicas: # Optional. Set min = max to disable autoscaling.
-    min: 4 # minimum number of replicas.
-    max: 6 # maximum number of replicas.
+    min: 2 # minimum number of replicas.
+    max: 2 # maximum number of replicas.
   leaderElection: true # Optional. If true, a http endpoint will be available at $ELECTOR_PATH that return the current leader
   # Compare this value with the $HOSTNAME to see if the current instance is the leader
   preStopHookPath: "" # Optional. A HTTP GET will be issued to this endpoint at least once before the pod is terminated.


### PR DESCRIPTION
Kan justere ned antall poder igjen, da det var index'en som ble lagt til som var hovedårsaken til forbedringen av ytelse. Unngår da å belaste basen unødig med oppvarming av cache for opptil fire poder ekstra ved oppstart