### PR TITLE
Fjerner på forespørsel fra Infotrygd bruken av Saksblokk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/repository/SakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/repository/SakRepository.kt
@@ -12,10 +12,7 @@ interface SakRepository : JpaRepository<Sak, Long> {
     @Query(
         """
         SELECT s FROM Sak s
-        INNER JOIN Saksblokk p
-                ON (s.personKey = p.personKey AND
-                    s.region = p.region)
-            WHERE p.fnr = :fnr 
+            WHERE s.fnr = :fnr 
               AND s.kapittelNr = 'BA' 
               AND s.type IN ('S', 'R', 'FL', 'AS', 'FS')""",
     ) // søknad, revurdering, klage, anke, flyttesak, automatisk stønad,

--- a/src/main/kotlin/no/nav/familie/ba/infotrygd/repository/SaksblokkRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/infotrygd/repository/SaksblokkRepository.kt
@@ -1,8 +1,0 @@
-package no.nav.familie.ba.infotrygd.repository
-
-import no.nav.familie.ba.infotrygd.model.dl1.Saksblokk
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
-
-@Repository
-interface SaksblokkRepository : JpaRepository<Saksblokk, Long>

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/repository/SakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/repository/SakRepositoryTest.kt
@@ -14,9 +14,6 @@ class SakRepositoryTest {
     lateinit var sakRepository: SakRepository
 
     @Autowired
-    lateinit var saksblokkRepository: SaksblokkRepository
-
-    @Autowired
     lateinit var stønadRepository: StønadRepository
 
     @Autowired
@@ -39,7 +36,6 @@ class SakRepositoryTest {
         val sak =
             sakRepository
                 .saveAndFlush(TestData.sak(person, stønad.saksblokk, stønad.sakNr))
-                .also { saksblokkRepository.saveAndFlush(TestData.saksblokk(person)) }
 
         sakRepository.findBarnetrygdsakerByFnr(person.fnr).also {
             assertThat(it).extracting("personKey").first().isEqualTo(person.personKey)

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/rest/controller/BarnetrygdControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/rest/controller/BarnetrygdControllerTest.kt
@@ -11,7 +11,6 @@ import no.nav.familie.ba.infotrygd.repository.EndringRepository
 import no.nav.familie.ba.infotrygd.repository.LøpeNrFnrRepository
 import no.nav.familie.ba.infotrygd.repository.PersonRepository
 import no.nav.familie.ba.infotrygd.repository.SakRepository
-import no.nav.familie.ba.infotrygd.repository.SaksblokkRepository
 import no.nav.familie.ba.infotrygd.repository.StønadDb2Repository
 import no.nav.familie.ba.infotrygd.repository.StønadRepository
 import no.nav.familie.ba.infotrygd.repository.UtbetalingRepository
@@ -62,9 +61,6 @@ class BarnetrygdControllerTest {
 
     @Autowired
     lateinit var sakRepository: SakRepository
-
-    @Autowired
-    lateinit var saksblokkRepository: SaksblokkRepository
 
     @Autowired
     lateinit var vedtakRepository: VedtakRepository
@@ -136,7 +132,6 @@ class BarnetrygdControllerTest {
     fun `infotrygdsøk etter saker by fnr`() {
         val person = personRepository.saveAndFlush(TestData.person())
         val sak = sakRepository.saveAndFlush(TestData.sak(person))
-        saksblokkRepository.saveAndFlush(TestData.saksblokk(person))
         val barn = barnRepository.saveAndFlush(TestData.barn(person))
 
         val søkPåPersonMedSak = InfotrygdSøkRequest(listOf(person.fnr))

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/service/BarnetrygdServiceTest.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ba.infotrygd.repository.HendelseRepository
 import no.nav.familie.ba.infotrygd.repository.LøpeNrFnrRepository
 import no.nav.familie.ba.infotrygd.repository.PersonRepository
 import no.nav.familie.ba.infotrygd.repository.SakRepository
-import no.nav.familie.ba.infotrygd.repository.SaksblokkRepository
 import no.nav.familie.ba.infotrygd.repository.StatusRepository
 import no.nav.familie.ba.infotrygd.repository.StønadRepository
 import no.nav.familie.ba.infotrygd.repository.StønadsklasseRepository
@@ -48,9 +47,6 @@ internal class BarnetrygdServiceTest {
 
     @Autowired
     private lateinit var sakRepository: SakRepository
-
-    @Autowired
-    private lateinit var saksblokkRepository: SaksblokkRepository
 
     @Autowired
     private lateinit var vedtakRepository: VedtakRepository
@@ -317,7 +313,6 @@ internal class BarnetrygdServiceTest {
                 ),
             )
         sakRepository.save(TestData.sak(person, stønad.saksblokk, stønad.sakNr))
-        saksblokkRepository.saveAndFlush(TestData.saksblokk(person))
         utbetalingRepository.save(TestData.utbetaling(stønad, utbetalingTom = stønadTom))
         barnRepository.save(TestData.barn(stønad))
 
@@ -446,7 +441,6 @@ internal class BarnetrygdServiceTest {
                 ),
             )
         sakRepository.save(TestData.sak(person, opphørtStønad.saksblokk, opphørtStønad.sakNr, valg = "UT", undervalg = "MB"))
-        saksblokkRepository.saveAndFlush(TestData.saksblokk(person))
 
         utbetalingRepository.save(TestData.utbetaling(opphørtStønad))
 
@@ -541,7 +535,6 @@ internal class BarnetrygdServiceTest {
                 }
 
         sakRepository.save(TestData.sak(person, løpendeStønad.saksblokk, løpendeStønad.sakNr, valg = "UT", undervalg = "MD"))
-        saksblokkRepository.saveAndFlush(TestData.saksblokk(person))
         utbetalingRepository.saveAll(
             listOf(
                 TestData.utbetaling(løpendeStønad, beløp = 1581.0), // utvidet på aktiv stønad
@@ -711,7 +704,6 @@ internal class BarnetrygdServiceTest {
                 ),
             )
         sakRepository.save(TestData.sak(person, opphørtStønad.saksblokk, opphørtStønad.sakNr, valg = "UT", undervalg = "MB"))
-        saksblokkRepository.saveAndFlush(TestData.saksblokk(person))
         if (beløp == null) {
             utbetalingRepository.save(TestData.utbetaling(opphørtStønad))
         } else {

--- a/src/test/kotlin/no/nav/familie/ba/infotrygd/testutil/TestData.kt
+++ b/src/test/kotlin/no/nav/familie/ba/infotrygd/testutil/TestData.kt
@@ -11,7 +11,6 @@ import no.nav.familie.ba.infotrygd.model.dl1.Barn
 import no.nav.familie.ba.infotrygd.model.dl1.Hendelse
 import no.nav.familie.ba.infotrygd.model.dl1.Person
 import no.nav.familie.ba.infotrygd.model.dl1.Sak
-import no.nav.familie.ba.infotrygd.model.dl1.Saksblokk
 import no.nav.familie.ba.infotrygd.model.dl1.Stønad
 import no.nav.familie.ba.infotrygd.nextId
 import no.nav.familie.ba.infotrygd.utils.DatoUtils
@@ -215,8 +214,6 @@ object TestData {
             fnr = stønad.fnr!!,
             tkNr = stønad.tkNr,
         )
-
-    fun saksblokk(person: Person): Saksblokk = Saksblokk(nextId(), person.region, person.personKey, person.fnr)
 
     fun hendelse(
         person: Person,


### PR DESCRIPTION
Kutter ut oppslag på SA_SAKSBLOKK_05. Opprinnelig ble joinen lagt på for å få indeksering i forbindelse med en tunge queries for skatteetaten i forbindelse med levering av utvidet data

Dette gjøres etter en epost fra Espen på infotrygd replikering

_Ref at dere har endret fra oppslag mot SA_PERSON_01 til SA_SAKSBLOKK_05....... (fordi vi i replikering mener at  SA_PERSON_01 er en unødvendig tabell, siden det ikke ligger andre opplysninger i den enn Personkey (som dere har i alle SA-tabellene)
Det optimale er faktisk om dere slår opp mot SA_SAK_10 i steden for SA_SAKSBLOKK_05. Årsaken er at SA_SAKSBLOKK_05 er stor og det virker ikke som dere har brukt den tabellen i det hele tatt tidligere._

Tjenesten er testet i preprod
